### PR TITLE
feat: add new format for station docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
+  - md_in_html
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
@@ -36,3 +37,6 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/bertiewils/tfldisruptioncalendars
+
+watch:
+  - scripts

--- a/scripts/gen_station_docs.py
+++ b/scripts/gen_station_docs.py
@@ -5,6 +5,19 @@ import mkdocs_gen_files
 FILE = "docs/calendars/all.json"
 SITE_URL = "tfldisruptioncalendars.uk"
 
+PER_STATION_FORMAT = """
+## {station_name}
+
+Modes: {station_modes}
+
+ID: {station_id}
+
+[Add to calendar :fontawesome-brands-apple:]({webcal_link}){{ .md-button }}
+[Add to calendar :fontawesome-brands-google:](https://www.google.com/calendar/render?cid={webcal_link}){{ .md-button }}
+[Copy to clipboard :fontawesome-regular-copy:](javascript:;){{ data-clipboard-text="{webcal_link}"  .md-button }}
+
+"""
+
 with open(FILE, "r") as file:
     all_stations = json.load(file)
 
@@ -16,16 +29,21 @@ for letter in sorted(first_letters):
     with mkdocs_gen_files.open(filename, "w") as f:
         print(f"# Stations beginning with {letter.upper()}", file=f)
 
-        print("| Station ID       | Station Name      | Station Modes      | Calendar Link      |", file=f)
-        print("|------------------|-------------------|--------------------|--------------------|", file=f)
-
         for station in all_stations:
             if station["commonName"][0].lower() == letter:
                 station_id = station["naptanId"]
                 station_name = station["commonName"]
                 station_modes = ", ".join(station["modes"])
-                calendar_link = f"[Add to calendar](webcal://{SITE_URL}/calendars/{station_id}.ics)"
+                webcal_link = f"webcal://{SITE_URL}/calendars/{station_id}.ics"
 
-                print(f"| {station_id} | {station_name} | {station_modes} | {calendar_link} |", file=f)
+                print(
+                    PER_STATION_FORMAT.format(
+                        station_name=station_name,
+                        station_modes=station_modes,
+                        station_id=station_id,
+                        webcal_link=webcal_link,
+                    ),
+                    file=f,
+                )
 
     mkdocs_gen_files.set_edit_path(filename, "gen_calendar_docs.py")


### PR DESCRIPTION
Add 'add to' links for:
- Plain webcal:// (works for Apple and most things)
- Google calendar
- Copy to clipboard.